### PR TITLE
Add airtable sync to deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 See [build/crontab](build/crontab).
 
 * Airtable backup to S3.
+* Airtable sync to Google Groups.
 * Chapter map data update.
 
 ###The Chapter Map!
@@ -51,6 +52,9 @@ API](https://developers.google.com/google-apps/spreadsheets/?hl=en) to grab them
 ###Attendance App
 A simple [web page](http://dxetech.org/attend) for organizers to create events and mark who attended it in the airtable database.
 
+###Sync Airtable to Google Groups
+
+Sync from Airtable to Google Groups.
 
 ##Background
 ###Build

--- a/airtable/airtable_to_mailing_list.py
+++ b/airtable/airtable_to_mailing_list.py
@@ -3,10 +3,14 @@
 import httplib2
 import json
 import airtable
+import logging
+import argparse
 from apiclient.errors import HttpError
 from apiclient.discovery import build
 from oauth2client.client import SignedJwtAssertionCredentials
 from collections import namedtuple
+
+logger = logging.getLogger(__name__)
 
 def get_directory():
     with open("../config/client_secret.json") as f:
@@ -109,33 +113,41 @@ def sync_airtable_to_mailing_list():
         valid_chapters_to_add = []
         for c in m.chapters_to_add:
             if c not in chapter_to_mailing_list:
-                print "Not adding member {} to chapter {} because it does not have a mailing list.".format(m.email, c)
+                logger.info("Not adding member %s to chapter %s because it does not have a mailing list.", m.email, c)
                 continue
             ml = chapter_to_mailing_list[c]
-            print "Adding member {} to chapter mailing list {} for chapter {}.".format(m.email, ml, c)
+            logger.info("Adding member %s to chapter mailing list %s for chapter %s.", m.email, ml, c)
             try:
                 directory.members().insert(groupKey=ml, body={"email": m.email.strip()}).execute()
                 valid_chapters_to_add.append(c)
-                print "Successfully added member {} to mailing list {}".format(m.email, ml)
+                logger.info("Successfully added member %s to mailing list %s", m.email, ml)
             except HttpError as e:
-                print e
-                print "Error adding member {} to mailing list {}.".format(m.email, ml)
+                logger.error(e)
+                logger.error("Error adding member %s to mailing list %s.", m.email, ml)
                 content = json.loads(e.content)
                 if "Member already exists" in content["error"]["message"]:
                     # Add member if the error is that they already exist.
                     valid_chapters_to_add.append(c)
-                    print "Adding member {} to chapter {} in Airtable anyway.".format(m.email, c)
+                    logger.warning("Adding member %s to chapter %s in Airtable anyway.", m.email, c)
         if not valid_chapters_to_add:
-            print "Not adding member {} to any chapter mailing lists, valid_chapters_to_add is empty".format(m.email)
+            logger.info("Not adding member %s to any chapter mailing lists, valid_chapters_to_add is empty", m.email)
             continue # Don't update the member if they weren't added to any chapter mailing lists.
         # Update member in airtable.
         valid_chapters_to_add += m.chapters_added
-        print "Updating member {}'s airtable column {} to {}".format(m.email, ADDED_TO_MAILING_LIST_COL, valid_chapters_to_add)
+        logger.info("Updating member %s's airtable column %s to %s", m.email, ADDED_TO_MAILING_LIST_COL, valid_chapters_to_add)
         r = airtable.update_record("All Members", m.airtable_id, {ADDED_TO_MAILING_LIST_COL: valid_chapters_to_add})
         if r.status_code != 200:
-            raise Exception("Error updating Airtable column {}, expected '200' from airtable.update_record: {}, {}, {}, {}".format(ADDED_TO_MAILING_LIST_COL, m.airtable_id, m.email, valid_chapters_to_add, r.text))
-    print "done!"
+            raise Exception("Error updating Airtable column %s, expected '200' from airtable.update_record: %s, %s, %s, %s".format(ADDED_TO_MAILING_LIST_COL, m.airtable_id, m.email, valid_chapters_to_add, r.text))
+    logger.info("done!")
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Airtable to Google Groups Sync.")
+    parser.add_argument("--log", choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
+                        default="WARNING", help="logging level (default: WARNING).")
+    args = parser.parse_args()
+    logging.basicConfig()
+    loglevel = getattr(logging, args.log)
+    logger.setLevel(loglevel)
+    handler = logging.StreamHandler()
     sync_airtable_to_mailing_list()

--- a/airtable/run_airtable_to_mailing_list.sh
+++ b/airtable/run_airtable_to_mailing_list.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+. /opt/dxe/airtable/conf.sh
+cd /opt/dxe/airtable
+/usr/bin/env python airtable_to_mailing_list.py

--- a/build/crontab
+++ b/build/crontab
@@ -7,3 +7,6 @@ MAILTO=tech-error-reporting@directactioneverywhere.com
 
 #update the chapter map data hourly
 0 * * * * /opt/dxe/airtable/run_generate_chapter_data.sh
+
+#sync airtable to google groups twice a day
+0 1,13 * * * make -C /opt/dxe/airtable/ sync

--- a/build/requirements.txt
+++ b/build/requirements.txt
@@ -6,7 +6,8 @@ gunicorn==19.3.0
 oauth2client==1.4.12
 requests[security]==2.7.0
 
-# requirements for airtable to google groups sync
-#requests[security]==2.7.0
+# Requirements for Airtable to Google Groups sync.
+# Also requires requests, which is required above.
 httplib2==0.9.2
 google-api-python-client==1.4.2
+

--- a/build/requirements.txt
+++ b/build/requirements.txt
@@ -5,3 +5,8 @@ gspread==0.2.5
 gunicorn==19.3.0
 oauth2client==1.4.12
 requests[security]==2.7.0
+
+# requirements for airtable to google groups sync
+#requests[security]==2.7.0
+httplib2==0.9.2
+google-api-python-client==1.4.2


### PR DESCRIPTION
Tested the pip requirements by creating a virtual env, doing `pip install -r build/requirements.txt`, and then running `make sync` in the airtable directory.

I also added more logging to the script.

Haven't tested it yet, though. Is the best way to test it to deploy a test server and then run the command in cron (`make -C /opt/dxe/airtable/ sync`) manually?