### PR TITLE
civicrm WIP

### DIFF
--- a/build/packer.json
+++ b/build/packer.json
@@ -6,6 +6,11 @@
     "size": "512mb",
     "image": "ubuntu-14-04-x64",
     "snapshot_name": "dxe-image-{{timestamp}}"
+  },
+  {
+    "type": "docker",
+    "image": "ubuntu:14.04",
+    "export_path": "image.tar"
   }],
   "provisioners": [
     {
@@ -13,7 +18,7 @@
       "inline": [
         "sleep 30",
         "sudo apt-get update",
-        "sudo apt-get install -y python-dev python-pip nginx upstart libpq-dev",
+        "sudo apt-get install -y python-dev python-pip nginx upstart libpq-dev libssl-dev libffi-dev build-essential wget",
         "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y postfix",
         "sudo apt-get install -y php5-fpm",
         "sudo apt-get install -y php5-curl",

--- a/install_drupal.sh
+++ b/install_drupal.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+sudo rm -rf drupal
+tar -xf ~/Downloads/drupal-7.43.tar.gz
+mv drupal-7.43 drupal
+cd drupal/sites/all/modules
+tar -xf ~/Downloads/civicrm-4.7.2-drupal.tar.gz
+cd ../../../..
+chmod u+w drupal/sites/default
+sudo chown www-data:www-data -R drupal


### PR DESCRIPTION
Setup for local testing. It works well with a local database (yay!) but it's too slow when installing on RDS from my laptop. Like, 10+ minute installs for drupal and my civicrm install didn't even finish before I needed to pack up and leave.

Next steps:
1. Talk with amazon support and see if RDS is supposed to be this slow.
2. See if it's faster talking to RDS over EC2 in the same region. If it is, generate an ec2 image from packer?

Check out the database install script: https://github.com/directactioneverywhere/config/blob/civicrm/setup_drupal_dbs.sh